### PR TITLE
Rails 7.1 support

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -95,6 +95,7 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
+        @connection = connection
       end
 
       # Returns the human-readable name of the adapter.


### PR DESCRIPTION
The changes in ActiveRecord 7.1 have broken adapter compatibility. Specifically, the[ adapter relies on `@connection`](https://github.com/doximity/odbc_adapter/blob/e3eff1577de0f06157e86b41745f7d6c14bb3376/lib/odbc_adapter/database_statements.rb#L23), which is no longer instantiated in `ActiveRecord::ConnectionAdapters::AbstractAdapter` [as of version 7.1.3.4](https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L131).

The main changes causing this break in compatibility are:

1. Renaming `@connection` to `@raw_connection`: [Pull Request #44530](https://github.com/rails/rails/pull/44530/files#diff-460f4e7973c5dd945c51d24df5b0173961190d3645f4e2585fd3003fa1fc0ff7L95)
2. Stopping the initialization of `@raw_connection` in the abstract adapter: [Pull Request #44591](https://github.com/rails/rails/pull/44591/files#diff-460f4e7973c5dd945c51d24df5b0173961190d3645f4e2585fd3003fa1fc0ff7R95)


This PR implements the simplest fix for this issue by assigning the `@connection` variable during the initialization of `ActiveRecord::ConnectionAdapters::AbstractAdapter`.

For future considerations, we should start using the new Active Record API, [which expects a config hash instead of the legacy connection](https://github.com/rails/rails/blob/19eebf6d33dd15a0172e3ed2481bec57a89a2404/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L134). Additionally, it would be beneficial to rename `@connection` to `@raw_connection` and utilize the `with_raw_connection` method, [similar to how other adapters implement it](https://github.com/rails/rails/blob/19eebf6d33dd15a0172e3ed2481bec57a89a2404/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb#L10-L17).