### PR TITLE
Apply Rails 7 improvements from `springbuk` fork; fix "size too big" errors for tables queries

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -175,7 +175,9 @@ module ActiveRecord
 
       # odbc_adapter does not support returning, so there are no return values from an insert
       def return_value_after_insert?(column) # :nodoc:
-        column.auto_incremented
+        # If the column is an ODBC Adapter column then we can use the auto_incremented flag
+        # otherwise, fallback to the default_function
+        column.is_a?(::ODBCAdapter::Column) ? column.auto_incremented : column.auto_populated?
       end
 
       class << self

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -95,7 +95,7 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
-        @connection = connection
+        @raw_connection = connection
       end
 
       # Returns the human-readable name of the adapter.
@@ -109,42 +109,46 @@ module ActiveRecord
         true
       end
 
+      # ODBC adapter does not support the returning clause
+      def supports_insert_returning?
+        false
+      end
+
       # CONNECTION MANAGEMENT ====================================
 
       # Checks whether the connection to the database is still active. This
       # includes checking whether the database is actually capable of
       # responding, i.e. whether the connection isn't stale.
       def active?
-        @connection.connected?
+        @raw_connection.connected?
       end
 
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database.
-      def reconnect!
+      def reconnect
         disconnect!
         odbc_module = @config[:encoding] == 'utf8' ? ODBC_UTF8 : ODBC
-        @connection =
+        @raw_connection =
           if @config.key?(:dsn)
             odbc_module.connect(@config[:dsn], @config[:username], @config[:password])
           else
             odbc_module::Database.new.drvconnect(@config[:driver])
           end
-        configure_time_options(@connection)
-        super
+        configure_time_options(@raw_connection)
       end
       alias reset! reconnect!
 
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
-        @connection.disconnect if @connection.connected?
+        @raw_connection.disconnect if @raw_connection.connected?
       end
 
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type)
+      def new_column(name, default, sql_type_metadata, null, native_type = nil, auto_incremented = false)
+        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type, auto_incremented)
       end
 
       #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched
@@ -169,29 +173,41 @@ module ActiveRecord
         exec_query(sql, name)
       end
 
-      protected
-
-      #Snowflake ODBC Adapter specific
-      def initialize_type_map(map)
-        map.register_type %r(boolean)i,               Type::Boolean.new
-        map.register_type %r(date)i,                  Type::Date.new
-        map.register_type %r(varchar)i,                Type::String.new
-        map.register_type %r(time)i,                  Type::Time.new
-        map.register_type %r(timestamp)i,              Type::DateTime.new
-        map.register_type %r(binary)i,                Type::Binary.new
-        map.register_type %r(double)i,                 Type::Float.new
-        map.register_type(%r(decimal)i) do |sql_type|
-          scale = extract_scale(sql_type)
-          if scale == 0
-            ::ODBCAdapter::Type::SnowflakeInteger.new
-          else
-            Type::Decimal.new(precision: extract_precision(sql_type), scale: scale)
-          end
-        end
-        map.register_type %r(struct)i,                ::ODBCAdapter::Type::SnowflakeObject.new
-        map.register_type %r(array)i,                 ::ODBCAdapter::Type::ArrayOfValues.new
-        map.register_type %r(variant)i,               ::ODBCAdapter::Type::Variant.new
+      # odbc_adapter does not support returning, so there are no return values from an insert
+      def return_value_after_insert?(column) # :nodoc:
+        column.auto_incremented
       end
+
+      class << self
+        private
+        #Snowflake ODBC Adapter specific
+        def initialize_type_map(map)
+          map.register_type %r(boolean)i,               Type::Boolean.new
+          map.register_type %r(date)i,                  Type::Date.new
+          map.register_type %r(varchar)i,                Type::String.new
+          map.register_type %r(time)i,                  Type::Time.new
+          map.register_type %r(timestamp)i,              Type::DateTime.new
+          map.register_type %r(binary)i,                Type::Binary.new
+          map.register_type %r(double)i,                 Type::Float.new
+          map.register_type(%r(decimal)i) do |sql_type|
+            scale = extract_scale(sql_type)
+            if scale == 0
+              ::ODBCAdapter::Type::SnowflakeInteger.new
+            else
+              Type::Decimal.new(precision: extract_precision(sql_type), scale: scale)
+            end
+          end
+          map.register_type %r(struct)i,                ::ODBCAdapter::Type::SnowflakeObject.new
+          map.register_type %r(array)i,                 ::ODBCAdapter::Type::ArrayOfValues.new
+          map.register_type %r(variant)i,               ::ODBCAdapter::Type::Variant.new
+        end
+
+      end
+
+      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+      EXTENDED_TYPE_MAPS = Concurrent::Map.new
+
+      protected
 
       # Translate an exception from the native DBMS to something usable by
       # ActiveRecord.

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -33,19 +33,7 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        serial_sequence(table_name, pk || 'id').split('.').last
-      rescue ActiveRecord::StatementInvalid
         "#{table_name}_#{pk || 'id'}_seq"
-      end
-
-      def sql_for_insert(sql, pk, binds)
-        unless pk
-          table_ref = extract_table_ref_from_insert_sql(sql)
-          pk = primary_key(table_ref) if table_ref
-        end
-
-        sql = "#{sql} RETURNING #{quote_column_name(pk)}" if pk
-        [sql, binds]
       end
 
       def type_cast(value, column)
@@ -178,15 +166,6 @@ module ODBCAdapter
       def last_insert_id(sequence_name)
         r = exec_query("SELECT currval('#{sequence_name}')", 'SQL')
         Integer(r.rows.first.first)
-      end
-
-      private
-
-      def serial_sequence(table, column)
-        result = exec_query(<<-eosql, 'SCHEMA')
-          SELECT pg_get_serial_sequence('#{table}', '#{column}')
-        eosql
-        result.rows.first.first
       end
     end
   end

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -1,13 +1,14 @@
 module ODBCAdapter
   class Column < ActiveRecord::ConnectionAdapters::Column
-    attr_reader :native_type
+    attr_reader :native_type, :auto_incremented
 
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, auto_incremented, **kwargs)
       super(name, default, sql_type_metadata, null, **kwargs)
       @native_type = native_type
+      @auto_incremented = auto_incremented
     end
   end
 end

--- a/lib/odbc_adapter/concerns/easy_identified.rb
+++ b/lib/odbc_adapter/concerns/easy_identified.rb
@@ -8,17 +8,17 @@ module ODBCAdapter
       alias_method :pre_easy_identified_save!, :save!
 
       def save(**options, &block)
-        if self[:id] == :auto_generate then generate_id(true) end
+        if self.id == :auto_generate then generate_id(true) end
         pre_easy_identified_save(**options, &block)
       end
 
       def save!(**options, &block)
-        if self[:id] == :auto_generate then generate_id(true) end
+        if self.id == :auto_generate then generate_id(true) end
         pre_easy_identified_save!(**options, &block)
       end
 
       def generate_id(force_new = false)
-        if self[:id] == nil || force_new then self[:id] = retrieve_id end
+        if self.id == nil || force_new then self.id = retrieve_id end
       end
 
       private

--- a/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
+++ b/lib/odbc_adapter/concerns/insert_attribute_stripper.rb
@@ -39,12 +39,13 @@ module ODBCAdapter
           end
           temp_options = options.merge(validate: false)
           first_call_result = base_function.call(**temp_options, &block)
-          return false if first_call_result == false
-          if stripped_attributes.any?
+          if first_call_result == false
+            false
+          elsif stripped_attributes.any?
             restore_stripped_attributes(stripped_attributes)
-            return base_function.call(**options, &block)
+            base_function.call(**options, &block)
           else
-            return first_call_result
+            first_call_result
           end
         end
       end

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -8,6 +8,7 @@ module ODBCAdapter
     # Executes the SQL statement in the context of this connection.
     # Returns the number of rows affected.
     def execute(sql, name = nil, binds = [])
+      sql = transform_query(sql)
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
         @raw_connection.do(sql)
@@ -25,6 +26,7 @@ module ODBCAdapter
     end
 
     def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
+      sql = transform_query(sql)
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
         stmt =  @raw_connection.run(sql)

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -28,7 +28,7 @@ module ODBCAdapter
     # sequence, but not all ODBC drivers support them.
     def quoted_date(value)
       if value.acts_like?(:time)
-        zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+        zone_conversion_method = ActiveRecord.default_timezone == :utc ? :getutc : :getlocal
 
         if value.respond_to?(zone_conversion_method)
           value = value.send(zone_conversion_method)

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -26,7 +26,14 @@ module ODBCAdapter
 
     # Returns an array of view names defined in the database.
     def views
-      []
+      views_query = "SHOW VIEWS IN SCHEMA #{current_schema}"
+
+      # Temporarily disable debug logging
+      query_results = ActiveRecord::Base.logger.silence do
+        exec_query(views_query)
+      end
+
+      query_results.map { |query_result| format_case(query_result["name"]) }
     end
 
     # Returns an array of indexes for the given table.

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -26,11 +26,15 @@ module ODBCAdapter
 
     # Returns an array of view names defined in the database.
     def views
-      views_query = "SHOW VIEWS IN SCHEMA #{current_schema}"
+      views_query = "SHOW VIEWS IN SCHEMA #{current_database}.#{current_schema}"
 
       # Temporarily disable debug logging
       query_results = ActiveRecord::Base.logger.silence do
-        exec_query(views_query)
+        begin
+          exec_query(views_query)
+        rescue ODBC_UTF8::Error
+          []
+        end
       end
 
       query_results.map { |query_result| format_case(query_result["name"]) }

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -193,7 +193,7 @@ module ODBCAdapter
     end
 
     def current_schema
-      @config[:driver].attrs['schema']
+      @config[:driver].attrs.transform_keys(&:downcase)['schema']
     end
 
     def name_regex(name)

--- a/lib/odbc_adapter/type/variant.rb
+++ b/lib/odbc_adapter/type/variant.rb
@@ -2,6 +2,10 @@ module ODBCAdapter
   module Type
     class Variant < ActiveRecord::Type::Value
 
+      def type
+        :variant
+      end
+
       def deserialize(value)
         # deserialize can contain the results of the previous serialize, rather than the database returned value
         if value.is_a? SnowflakeVariant then return value.internal_data end

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 5.0.1'
+  spec.add_dependency 'activerecord', '>= 7.1.2'
   spec.add_dependency 'ruby-odbc', '~> 0.99998'
 
   spec.add_development_dependency 'bundler', '>= 1.14'


### PR DESCRIPTION
This PR pulls in the following updates from the `springbuk` fork to improve Rails 7 compatibility:

https://github.com/springbuk/odbc_adapter/compare/ecd6964fd8bd2ca38efb528e15c8fd309937d07f...f911e79d06456ab4d195f5704ff0d932648177ea

This PR also applies the following changes/fixes:

- Fixes an issue where the `tables` method would throw a `negative string size (or size too big)` error while attempting to pull tables with longer comments (see https://github.com/doximity/odbc_adapter/commit/88fc21e9cc48a89c9a96aae7046f6788f30681d5).
- Makes the `schema` driver attribute lookup case-insensitive (see https://github.com/doximity/odbc_adapter/commit/23ab5a40f30454ba93b3a87544e2375f6fc07667).

HCM-6312