### PR TITLE
Allow odbc_adapter to be installed on Rails >= 7.0

### DIFF
--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 7.1.2'
+  spec.add_dependency 'activerecord', '>= 7.0'
   spec.add_dependency 'ruby-odbc', '~> 0.99998'
 
   spec.add_development_dependency 'bundler', '>= 1.14'


### PR DESCRIPTION
Since `Campaigns` is on Rails 7.0.x we need to be able to use the latest changes in the driver, so this PR relaxes the `activerecord` requirement to support the Rails version we currently use.