### PR TITLE
Improved Rails 7.2 Compatibility

### DIFF
--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -25,7 +25,7 @@ module ODBCAdapter
       id_value
     end
 
-    def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
+    def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false, allow_retry: false) # rubocop:disable Lint/UnusedMethodArgument
       sql = transform_query(sql)
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -5,6 +5,11 @@ module ODBCAdapter
       string.gsub(/\'/, "''")
     end
 
+    # Returns a quoted form of the table name.
+    def quote_table_name(name)
+      quote_column_name(name)
+    end
+
     # Returns a quoted form of the column name.
     def quote_column_name(name)
       name = name.to_s

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '6.0.1'.freeze
+  VERSION = '6.0.2'.freeze
 end


### PR DESCRIPTION
Rails 7.2 introduced a few under-the-hood changes to ActiveRecord that impact how database adapters behave. As a result, this adapter currently raises errors when used with the ActiveRecord DSL in a Rails 7.2 application. While raw SQL execution still appears to work, full compatibility with the DSL is ideal.

This PR introduces the following changes to improve compatibility with Rails 7.2 and restore AR DSL functionality:

**Add optional `allow_retry` argument to exec query**

Rails 7.1 introduced the ability to specify an `allow_retry` option, allowing queries to be retried per the databases configured retries value if a connection-related error occurs ([source](https://github.com/rails/rails/blob/40a0294faf6c8aefdbad16d88d3b94fa3050f6dd/activerecord/CHANGELOG.md?plain=1#L1844-L1845)). This option appears to be explicitly passed over through to `internal_exec_query` as of Rails 7.2, resulting in argument errors when queries are triggered via AR DSL.

This updates `internal_exec_query` to accept an optional `allow_retry` argument so that it is compatible with Rails 7.2+ where such an argument may be forwarded to the method.

**Explicitly define `quote_table_name` in adapter**

The abstract adapter was reworked in Rails 7.2+ to define its table and column quoting logic at the class level, eliminating the need for an active connection instance to access said quoting logic - this change was introduced via https://github.com/rails/rails/pull/51174

As a consequence of the above mentioned rework, the `quote_table_name` and `quote_table_column` methods aren't accessible in the same way to subclasses in Rails 7.2+ as they were in prior versions. This results in table names being quoted inconsistent with column names, as the latter is explicitly defined on this adapter while the former is not.

This explicitly defines the `quote_table_name` method for the ODBC adapter to ensure consistent behavior between Rails versions (i.e 7.1, 7.2, and beyond).

This approach was taken as the most minimally intrusive change to the adapter, but if at some point the gem drops support for Rails 7.1, the `ODBCAdapter::Quoting` logic can be tweaked to be more in line with the newer approach taken for adapters in Rails 7.2+, as shown in https://github.com/rails/rails/pull/51174. Specifically, the `quote_column_name` could be defined as a class method, allowing the superclass definitions to do the rest of the lifting, e.g:

```ruby
module ODBCAdapter
  module Quoting
    extend ActiveSupport::Concern

    module ClassMethods
      def quote_column_name(name)
        # ...
      end
    end

    # ...
  end
end
```

Though looking at the current `quote_column_name` implementation for this adapter, it might need to be reworked to not depend on an instance-level connection, as it currently appears to require one for accessing various database metadata info (see [here](https://github.com/doximity/odbc_adapter/blob/724e76261e8eb0173cd80477696a66c54f8b1e97/lib/odbc_adapter/quoting.rb#L11)).