### PR TITLE
Improved Rails 8.1 Compatibility

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -137,8 +137,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, native_type = nil, auto_incremented = false)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type, auto_incremented)
+      def new_column(name, cast_type, default, sql_type_metadata, null, native_type = nil, auto_incremented = false)
+        ::ODBCAdapter::Column.new(name, cast_type, default, sql_type_metadata, null, native_type, auto_incremented)
       end
 
       #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -134,13 +134,6 @@ module ActiveRecord
         @raw_connection.disconnect if @raw_connection.connected?
       end
 
-      # Build a new column object from the given options. Effectively the same
-      # as super except that it also passes in the native type.
-      # rubocop:disable Metrics/ParameterLists
-      def new_column(*, native_type: nil, auto_incremented: false)
-        ::ODBCAdapter::Column.new(*, native_type: native_type, auto_incremented: auto_incremented)
-      end
-
       #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched
       def prefetch_primary_key?(table_name = nil)
         true

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -137,8 +137,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, cast_type, default, sql_type_metadata, null, native_type = nil, auto_incremented = false)
-        ::ODBCAdapter::Column.new(name, cast_type, default, sql_type_metadata, null, native_type, auto_incremented)
+      def new_column(*, native_type: nil, auto_incremented: false)
+        ::ODBCAdapter::Column.new(*, native_type: native_type, auto_incremented: auto_incremented)
       end
 
       #Snowflake doesn't have a mechanism to return the primary key on inserts, it needs prefetched

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,9 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, cast_type, default, sql_type_metadata = nil, null = true, native_type = nil, auto_incremented, **kwargs)
-      super(name, cast_type, default, sql_type_metadata, null, **kwargs)
+    def initialize(*, native_type: nil, auto_incremented: false, **)
+      super
+
       @native_type = native_type
       @auto_incremented = auto_incremented
     end

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, auto_incremented, **kwargs)
-      super(name, default, sql_type_metadata, null, **kwargs)
+    def initialize(name, cast_type, default, sql_type_metadata = nil, null = true, native_type = nil, auto_incremented, **kwargs)
+      super(name, cast_type, default, sql_type_metadata, null, **kwargs)
       @native_type = native_type
       @auto_incremented = auto_incremented
     end

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -5,6 +5,16 @@ module ODBCAdapter
     SQL_NULLABLE = 1
     SQL_NULLABLE_UNKNOWN = 2
 
+    READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
+      :close, :declare, :fetch, :set, :show
+    )
+
+    def write_query?(sql)
+      !READ_QUERY.match?(sql)
+    rescue ArgumentError # Invalid encoding
+      !READ_QUERY.match?(sql.b)
+    end
+
     # Executes the SQL statement in the context of this connection.
     # Returns the number of rows affected.
     def execute(sql, name = nil, binds = [])

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -143,7 +143,7 @@ module ODBCAdapter
 
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type, auto_incremented)
+        cols << new_column(format_case(col_name), lookup_cast_type_from_column(sql_type_metadata), col_default, sql_type_metadata, col_nullable, col_native_type, auto_incremented)
       end
     end
 

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -143,7 +143,18 @@ module ODBCAdapter
 
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        cols << new_column(format_case(col_name), lookup_cast_type_from_column(sql_type_metadata), col_default, sql_type_metadata, col_nullable, col_native_type, auto_incremented)
+        new_column_args = []
+        new_column_args << format_case(col_name)
+        new_column_args << lookup_cast_type_from_column(sql_type_metadata) if ActiveRecord.version >= "8.1.0"
+        new_column_args << col_default
+        new_column_args << sql_type_metadata
+        new_column_args << col_nullable
+
+        cols << new_column(
+          *new_column_args,
+          native_type: col_native_type,
+          auto_incremented: auto_incremented
+        )
       end
     end
 

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -150,7 +150,7 @@ module ODBCAdapter
         new_column_args << sql_type_metadata
         new_column_args << col_nullable
 
-        cols << new_column(
+        cols << ::ODBCAdapter::Column.new(
           *new_column_args,
           native_type: col_native_type,
           auto_incremented: auto_incremented


### PR DESCRIPTION
This makes a few updates to the adapter to improve Rails 8.1 compatibility:

- Defines `write_query?` for this adapter
  - As of Rails 8.1, some of Active Record's adapter internals have been refactored to eliminate duplicate `write_query?` method calls via [this change](https://github.com/rails/rails/commit/07854a55607f845a72c4a9d43d4bedfe954d038c). As a result, `write_query?` now actually gets called in this adapter as it runs immediately when `preprocess_query` is called and then raises via `NotImplementedError` as it was not being defined - this wasn't an issue before as previously the check seems to have been short circuiting at `preventing_writes?` ([source](https://github.com/rails/rails/blob/529f933fc8b13114d308dd0752f76a9e293c8537/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L196)).
- Passes cast type when initializing Column instances for Rails 8.1.0+
  - As of Rails 8.1, the `ActiveRecord::ConnectionAdapters::Column` expects to receive a `cast_type` argument on instantiation (introduced via [this change](https://github.com/rails/rails/commit/9ad36e067222478090b36a985090475bb03e398c)). This updates the adapter code to pass the cast type as expected for ActiveRecord 8.1+ while retaining compatibility with older ActiveRecord versions.